### PR TITLE
Make readData function async

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -136,8 +136,5 @@ export interface DataParser {
    *
    * @param inputData
    */
-  readData(inputData: any): Data;
+  readData(inputData: any): Promise<Data>;
 }
-
-
-


### PR DESCRIPTION
The ``readData`` interface definition is now returning a Promise object. So asynchronous stuff can be handled in concrete parser implementations, e.g. a WFS parser, which loads the its data by AJAX.

Closes #2.