### PR TITLE
Extends parser interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,6 +116,16 @@ export interface Data {
  */
 export interface DataParser {
   /**
+   * Constructor interface
+   */
+  new(): DataParser;
+
+  /**
+   * The name of the Parser instance
+   */
+  name: string;
+
+  /**
    * Optional projection of the input data,
    * e.g. 'EPSG:4326'
    *


### PR DESCRIPTION
This adds some needed props and methods to the `DataParser` interface:

- `new`: This is needed to allow the construction of this interface. E.g:
```typescript
const myParsers: DataParser[] = [
  GeoJsonParser,
  WfsParser,
  …
];
const parserInstance = new myParsers[0]();
parserInstance.readData(geojson);
…
```
- `name`: The name for the parser. Useful for the visual representation of a parser. 