### PR TITLE
Introduces constructable interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,11 +116,6 @@ export interface Data {
  */
 export interface DataParser {
   /**
-   * Constructor interface
-   */
-  new(): DataParser;
-
-  /**
    * The name of the Parser instance
    */
   name: string;
@@ -147,4 +142,11 @@ export interface DataParser {
    * @param inputData
    */
   readData(inputData: any): Promise<Data>;
+}
+
+export interface DataParserConstructable extends DataParser {
+  /**
+   * Constructor interface
+   */
+  new(): DataParser;
 }


### PR DESCRIPTION
This introduces the `DataParserConstructable` and moves the constructor interface into it.
The reason is that extending the `DataParser` with included constructor interface was impossible.

To instantiate an unknown type of a `DataParser` it is know needed to use the `DataParserConstructable` instead of the `DataParser`. Everything else will work as before.

Compare: https://stackoverflow.com/a/13408029