### PR TITLE
Refactors name to title

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,11 +116,6 @@ export interface Data {
  */
 export interface DataParser {
   /**
-   * The name of the Parser instance
-   */
-  name: string;
-
-  /**
    * Optional projection of the input data,
    * e.g. 'EPSG:4326'
    *
@@ -149,4 +144,8 @@ export interface DataParserConstructable extends DataParser {
    * Constructor interface
    */
   new(): DataParser;
+  /**
+   * The name of the Parser instance
+   */
+  title: string;
 }


### PR DESCRIPTION
This refactors the `name` property of the `DataParser` for two reasons.
1. The name should definetly be static. But as you can't model static properties on an interface in TypeScript, we set it on the `DataParserConstructable`.
2. As the `name` property allready exists on `[function].constructor` we rename it to `title`.