### PR TITLE
Use json schema datatype instead of string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@
 // TypeScript Version: 2.8
 
 import { FeatureCollection, GeometryObject } from 'geojson';
+import { JSONSchema4TypeName } from 'json-schema';
 
 /**
  * Type represents a single property of an object according to JSON schema.
@@ -23,9 +24,9 @@ export type SchemaProperty = {
 
   /**
    * The data type of the described property / attribute
-   * @type {string}
+   * @type {JSONSchema4TypeName}
    */
-  type: string;
+  type: JSONSchema4TypeName;
 
   /**
    * The minimum value of the described property / attribute.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "10.5.2",
+    "@types/json-schema": "6.0.1",
     "@types/geojson": "7946.0.4",
     "@types/jest": "23.1.4",
     "jest": "23.1.0",


### PR DESCRIPTION
Title says it all.

This affects existing parsers for WFS and GeoJSON.