### PR TITLE
Updates the definition of exampleFeatures

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions:
 // TypeScript Version: 2.8
 
-import { FeatureCollection, GeometryObject } from 'geojson';
+import { FeatureCollection, Geometry } from 'geojson';
 import { JSONSchema4TypeName } from 'json-schema';
 
 /**
@@ -109,7 +109,7 @@ export interface Data {
   /**
    * Example features of imported geo-data
    */
-  exampleFeatures: FeatureCollection<GeometryObject>;
+  exampleFeatures: FeatureCollection<Geometry>;
 }
 
 /**


### PR DESCRIPTION
This updates the definition of `exampleFeatures`.

We need `FeatureCollection<Geometry>` here as the `GeometryObject` does not allow coordinates.
A `FeatureCollection` also expects something that extends `GeometryObject` and not `GeometryObject` itself. This can be one of `Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon | GeometryCollection` which is collected by the `Geometrie` interface.
