### PR TITLE
Add definition for rasterdata

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -78,7 +78,7 @@ export type DataSchema = {
   title?: string;
 
   /**
-   * Optional type definition for the described entity
+   * Type definition for the described entity
    *
    * @type {string}
    */
@@ -90,6 +90,18 @@ export type DataSchema = {
    * @type {[name: string]: SchemaProperty; }}
    */
   properties: { [name: string]: SchemaProperty };
+};
+
+/**
+ * Type represents the schema of imported raster-data,
+ * to have information about a single band.
+ *
+ * @type BandSchema
+ */
+export type BandSchema = {
+  minValue?: number;
+  maxValue?: number;
+  [key: string]: any;
 };
 
 /**
@@ -109,6 +121,13 @@ export interface Data {
    * Example features of imported geo-data
    */
   exampleFeatures: FeatureCollection<Geometry>;
+
+  /**
+   * Info on imported raster bands. Only used for raster data.
+   * Each band should be a unique key with arbitrary subproperties.
+   * These can include projections, statistics and other information.
+   */
+  rasterBandInfo?: {[bandname: string]: BandSchema }
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,9 +105,9 @@ export type BandSchema = {
 };
 
 /**
- * Internal data object for imported geo data.
+ * BaseData object
  */
-export interface Data {
+export interface BaseData {
   /**
    * Schema of imported geo-data describing the properties / attributes
    *
@@ -120,7 +120,7 @@ export interface Data {
  * Internal data object for imported vector geo data.
  * Aggregates a data schema and some example data (FeatureCollection).
  */
-export interface VectorData extends Data {
+export interface VectorData extends BaseData {
   /**
    * Example features of imported geo-data
    */
@@ -131,7 +131,7 @@ export interface VectorData extends Data {
  * Internal data object for imported raster data.
  * Aggregates a data schema and some example data.
  */
-export interface RasterData extends Data {
+export interface RasterData extends BaseData {
   /**
    * Info on imported raster bands.
    * Each band should be a unique key with arbitrary subproperties.
@@ -139,6 +139,11 @@ export interface RasterData extends Data {
    */
   rasterBandInfo: {[bandname: string]: BandSchema }
 }
+
+/**
+ * Internal data object for imported geo data.
+ */
+export type Data = RasterData | VectorData;
 
 /**
  * Interface, which has to be implemented by all GeoStyler parser classes.
@@ -165,7 +170,7 @@ export interface DataParser {
    *
    * @param inputData
    */
-  readData(inputData: any): Promise<VectorData>|Promise<RasterData>;
+  readData(inputData: any): Promise<Data>;
 }
 
 export interface DataParserConstructable extends DataParser {

--- a/index.d.ts
+++ b/index.d.ts
@@ -106,28 +106,38 @@ export type BandSchema = {
 
 /**
  * Internal data object for imported geo data.
- * Aggregates a data schema and some example data (FeatureCollection).
  */
 export interface Data {
-
   /**
    * Schema of imported geo-data describing the properties / attributes
    *
    * @type {DataSchema}
    */
   schema: DataSchema;
+}
 
+/**
+ * Internal data object for imported vector geo data.
+ * Aggregates a data schema and some example data (FeatureCollection).
+ */
+export interface VectorData extends Data {
   /**
    * Example features of imported geo-data
    */
   exampleFeatures: FeatureCollection<Geometry>;
+}
 
+/**
+ * Internal data object for imported raster data.
+ * Aggregates a data schema and some example data.
+ */
+export interface RasterData extends Data {
   /**
-   * Info on imported raster bands. Only used for raster data.
+   * Info on imported raster bands.
    * Each band should be a unique key with arbitrary subproperties.
    * These can include projections, statistics and other information.
    */
-  rasterBandInfo?: {[bandname: string]: BandSchema }
+  rasterBandInfo: {[bandname: string]: BandSchema }
 }
 
 /**
@@ -155,7 +165,7 @@ export interface DataParser {
    *
    * @param inputData
    */
-  readData(inputData: any): Promise<Data>;
+  readData(inputData: any): Promise<VectorData>|Promise<RasterData>;
 }
 
 export interface DataParserConstructable extends DataParser {


### PR DESCRIPTION
# Breaking Change

Introduced two new interfaces `VectorData` and `RasterData` that extend `BaseData`. Now, `Data` is either `RasterData` or `VectorData`. Updated the readFile output parameter of `DataParser` accordingly.

Due to the refactoring of `Data`, this is a breaking change.