### PR TITLE
Removes constructable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,6 +116,10 @@ export interface Data {
  */
 export interface DataParser {
   /**
+   * The name of the Parser instance
+   */
+  title: string;
+  /**
    * Optional projection of the input data,
    * e.g. 'EPSG:4326'
    *
@@ -137,15 +141,4 @@ export interface DataParser {
    * @param inputData
    */
   readData(inputData: any): Promise<Data>;
-}
-
-export interface DataParserConstructable extends DataParser {
-  /**
-   * Constructor interface
-   */
-  new(): DataParser;
-  /**
-   * The name of the Parser instance
-   */
-  title: string;
 }


### PR DESCRIPTION
# Breaking Change

The `DataParserConstructable` gets removed in this PR.

This keeps the `geostyler-data` concept to be in sync with the `geostyler-style`.
Compare: https://github.com/terrestris/geostyler-style/pull/117